### PR TITLE
Tool to make WARC files from tweets in Apache Kafka

### DIFF
--- a/twitter/setup.py
+++ b/twitter/setup.py
@@ -15,11 +15,13 @@ setup(
         'ujson',
         'configobj',
         'oauth2-utf8==1.5.170',
-        'kafka-python'
+        'kafka-python',
+        'PyYAML'
         ],
     scripts=[
         'archivestream.py',
-        'kafkastream.py'
+        'kafkastream.py',
+        'tweetwarc.py'
         ],
     zip_safe=False
     )

--- a/twitter/tweetwarc.py
+++ b/twitter/tweetwarc.py
@@ -51,7 +51,7 @@ def warcinfo_record(warc_filename):
             (WarcRecord.DATE, warc_date),
             (WarcRecord.FILENAME, warc_filename)
         ],
-        content=(b'warcinfo', metadata + "\r\n"),
+        content=(b'application/warc-fields', metadata + "\r\n"),
         version=b"WARC/1.0"
     )
 

--- a/twitter/tweetwarc.py
+++ b/twitter/tweetwarc.py
@@ -124,7 +124,6 @@ f = open(target_filename, "ab")
 record = warcinfo_record(base_filename)
 record.write_to(f, gzip=True)
 
-tweet_cnt = 0
 start_time = time()
 time_limit = config.get('warc_time_limit')
 size_limit = config.get('warc_size_limit')
@@ -133,11 +132,10 @@ for msg in consumer:
     record = tweet_warc_record(base_filename, tweet)
     if record:
         record.write_to(f, gzip=True)
-        tweet_cnt += 1
 
-    if tweet_cnt > size_limit or (time() - start_time) > time_limit:
+    if os.stat(target_filename).st_size > size_limit or \
+            (time() - start_time) > time_limit:
         consumer.commit()
-        tweet_cnt = 0
         start_time = time()
         f.close()
         # remove .open suffix from complete WARC file

--- a/twitter/tweetwarc.py
+++ b/twitter/tweetwarc.py
@@ -51,7 +51,7 @@ def warcinfo_record(warc_filename):
             (WarcRecord.DATE, warc_date),
             (WarcRecord.FILENAME, warc_filename)
         ],
-        content=(b'application/warc-fields', metadata + "\r\n"),
+        content=(b'application/warc-fields', metadata),
         version=b"WARC/1.0"
     )
 
@@ -94,7 +94,7 @@ def tweet_warc_record(warc_filename, tweet_json):
             (WarcRecord.FILENAME, warc_filename)
         ],
         content=(b'application/json',
-                 content_http_headers + "\r\n\r\n" + tweet_json + "\r\n"),
+                 content_http_headers + "\r\n\r\n" + tweet_json),
         version=b"WARC/1.0"
     )
 

--- a/twitter/tweetwarc.py
+++ b/twitter/tweetwarc.py
@@ -52,7 +52,7 @@ def warcinfo_record(warc_filename):
             (WarcRecord.DATE, warc_date),
             (WarcRecord.FILENAME, warc_filename)
         ],
-        content=(b'application/warc-fields', metadata),
+        content=(b'application/warc-fields', metadata + "\r\n"),
         version=b"WARC/1.0"
     )
 
@@ -85,7 +85,7 @@ def tweet_warc_record(warc_filename, tweet_json):
             (WarcRecord.DATE, warc_date),
             (WarcRecord.FILENAME, warc_filename)
         ],
-        content=(b'application/json', tweet_json),
+        content=(b'application/json', tweet_json + "\r\n"),
         version=b"WARC/1.0"
     )
 

--- a/twitter/tweetwarc.py
+++ b/twitter/tweetwarc.py
@@ -143,7 +143,6 @@ for msg in consumer:
         # remove .open suffix from complete WARC file
         os.rename(target_filename, target_filename[:-5])
         logging.info("Created file %s", target_filename[:-5])
-        break
         # create new file
         target_filename = warc_filename(args.directory)
         logging.info("Archiving to file " + target_filename)

--- a/twitter/tweetwarc.py
+++ b/twitter/tweetwarc.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""
+Create WARC files from tweets stored in Apache Kafka in user defined dir.
+Read configuration from YAML file. Run like this:
+    tweetwarc.py -c tweetwarc.yaml -d /dir-to-save-warc
+"""
+from __future__ import unicode_literals
+import argparse
+import yaml
+import hashlib
+import uuid
+import json
+import logging
+import os
+from datetime import datetime
+from time import time
+from hanzo.warctools import WarcRecord
+from hanzo.warctools.warc import warc_datetime_str
+from kafka import KafkaConsumer
+
+logging.basicConfig(level=logging.INFO)
+
+
+def warc_uuid(text):
+    """Utility method for WARC header field urn:uuid"""
+    return ("<urn:uuid:%s>" %
+            uuid.UUID(hashlib.sha1(text).hexdigest()[0:32])).encode('ascii')
+
+
+def warc_filename(directory):
+    """WARC filename example: /tmp/tweets20170307100027.warc.gz.open
+    After the file is closed, remove the .open suffix
+    """
+    return "%s/tweets%s.warc.gz.open" % (
+        directory, datetime.utcnow().strftime('%Y%m%d%H%M%S'))
+
+def warcinfo_record(warc_filename):
+    """Return warcinfo WarcRecord.
+    Required to write in the beginning of a WARC file.
+    """
+    warc_date = warc_datetime_str(datetime.now())
+    metadata = "\r\n".join((
+        "format: WARC File Format 1.0",
+        "conformsTo: http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf"
+    ))
+    return WarcRecord(
+        headers=[
+            (WarcRecord.TYPE, WarcRecord.WARCINFO),
+            (WarcRecord.CONTENT_TYPE, b'application/warc-fields'),
+            (WarcRecord.ID, warc_uuid(metadata+warc_date)),
+            (WarcRecord.DATE, warc_date),
+            (WarcRecord.FILENAME, warc_filename)
+        ],
+        content=(b'warcinfo', metadata + "\r\n"),
+        version=b"WARC/1.0"
+    )
+
+
+def tweet_warc_record(warc_filename, tweet_json):
+    """Parse Tweet JSON and return WarcRecord.
+    """
+    try:
+        tweet = json.loads(tweet_json)
+        # skip deleted tweet
+        if 'user' not in tweet:
+            return
+        url = "twitter:timelineapi/%s/%s/%s" % (
+            tweet['user']['screen_name'],
+            datetime.fromtimestamp(float(tweet['timestamp_ms'])/1000.0)
+                    .strftime("%Y%m%d%H%M%S"),
+            tweet['id']
+        )
+    except Exception as ex:
+        logging.error(ex)
+        return
+
+    current_date = datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT')
+    content_http_headers = "\r\n".join((
+        "HTTP/1.1 200 OK",
+        "Date: %s" % current_date,
+        "Last-Modified: %s" % current_date,
+        "Content-Length: %d" % len(tweet_json),
+        "Connection: close",
+        "Content-Type: application/json; charset=UTF-8"
+    ))
+    warc_date = warc_datetime_str(datetime.now())
+    return WarcRecord(
+        headers=[
+            (WarcRecord.TYPE, WarcRecord.CONVERSION),
+            (WarcRecord.CONTENT_TYPE, b'application/json'),
+            (WarcRecord.ID, warc_uuid(url+warc_date)),
+            (WarcRecord.URL, url),
+            (WarcRecord.DATE, warc_date),
+            (WarcRecord.FILENAME, warc_filename)
+        ],
+        content=(b'application/json',
+                 content_http_headers + "\r\n\r\n" + tweet_json + "\r\n"),
+        version=b"WARC/1.0"
+    )
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--config', default='./tweetwarc.yaml',
+                    help='YAML configuration file (default %(default)s)s')
+parser.add_argument('-d', '--directory', default=False,
+                    help='Directory to store tweets WARC.')
+args = parser.parse_args()
+
+with open(args.config) as f:
+    config = yaml.load(f)
+
+consumer = KafkaConsumer(
+    bootstrap_servers=config.get('kafka_bootstrap_servers'),
+    client_id=config.get('kafka_client_id'),
+    group_id=config.get('kafka_group_id')
+)
+consumer.subscribe([config.get('kafka_topic')])
+
+target_filename = warc_filename(args.directory)
+logging.info("Archiving to file " + target_filename)
+# drop .open suffix inside WARC
+base_filename = os.path.basename(target_filename)[:-5]
+f = open(target_filename, "ab")
+record = warcinfo_record(base_filename)
+record.write_to(f, gzip=True)
+
+tweet_cnt = 0
+start_time = time()
+time_limit = config.get('warc_time_limit')
+size_limit = config.get('warc_size_limit')
+for msg in consumer:
+    tweet = msg.value.decode('utf-8').split("\n")[-2]
+    record = tweet_warc_record(base_filename, tweet)
+    if record:
+        record.write_to(f, gzip=True)
+        tweet_cnt += 1
+
+    if tweet_cnt > size_limit or (time() - start_time) > time_limit:
+        consumer.commit()
+        tweet_cnt = 0
+        start_time = time()
+        f.close()
+        # remove .open suffix from complete WARC file
+        os.rename(target_filename, target_filename[:-5])
+        logging.info("Created file %s", target_filename[:-5])
+        break
+        # create new file
+        target_filename = warc_filename(args.directory)
+        logging.info("Archiving to file " + target_filename)
+        # drop .open suffix inside WARC
+        base_filename = os.path.basename(target_filename)
+        f = open(target_filename, "ab")
+        record = warcinfo_record(base_filename)
+        record.write_to(f, gzip=True)

--- a/twitter/tweetwarc.yaml.sample
+++ b/twitter/tweetwarc.yaml.sample
@@ -1,0 +1,7 @@
+kafka_topic: <TOPIC>
+kafka_bootstrap_servers: <HOST>:<PORT>
+kafka_client_id: <CID>
+kafka_group_id: <GID>
+
+warc_time_limit: 43200  # 12*3600, max open time for warc file
+warc_size_limit: 10000  # max number of tweets per warc file

--- a/twitter/tweetwarc.yaml.sample
+++ b/twitter/tweetwarc.yaml.sample
@@ -4,4 +4,4 @@ kafka_client_id: <CID>
 kafka_group_id: <GID>
 
 warc_time_limit: 43200  # 12*3600, max open time for warc file
-warc_size_limit: 10000  # max number of tweets per warc file
+warc_size_limit: 1000000000  # max warc filesize in bytes


### PR DESCRIPTION
Cli tool tweetwarc.py which reads tweets saved in Apache Kafka and
creates WARC files in directory.
Include sample configuration file.