### PR TITLE
Change link in readme because project was moved.

### DIFF
--- a/wikipedia/producer/README.md
+++ b/wikipedia/producer/README.md
@@ -1,7 +1,7 @@
 Vinay Goel
 (vinay@archive.org)
 
-This project contains scripts to extract links from live Wikipedia edits. It leverages the Wikipedia Live Monitor project (https://github.com/tomayac/wikipedia-irc)
+This project contains scripts to extract links from live Wikipedia edits. It leverages the Wikipedia Live Monitor project ([https://github.com/tomayac/wikipedia-irc](https://github.com/tomayac/wikipedia-live-monitor))
 
 The "monitor" application monitors article edits as they occur in realtime on all the different language Wikipedia versions. If the edit includes URL references, then these links are extracted. In the case of "new" articles, the Wikipedia API is used to extract all the external links on the article page. 
 

--- a/wikipedia/producer/README.md
+++ b/wikipedia/producer/README.md
@@ -1,7 +1,7 @@
 Vinay Goel
 (vinay@archive.org)
 
-This project contains scripts to extract links from live Wikipedia edits. It leverages the Wikipedia Live Monitor project ([https://github.com/tomayac/wikipedia-irc](https://github.com/tomayac/wikipedia-live-monitor))
+This project contains scripts to extract links from live Wikipedia edits. It leverages the Wikipedia Live Monitor project (https://github.com/tomayac/wikipedia-live-monitor)
 
 The "monitor" application monitors article edits as they occur in realtime on all the different language Wikipedia versions. If the edit includes URL references, then these links are extracted. In the case of "new" articles, the Wikipedia API is used to extract all the external links on the article page. 
 


### PR DESCRIPTION
Changes a link in the readme file because the project it links to has been moved.